### PR TITLE
Updating the templates to support k8 1.16. Essentially updating the d…

### DIFF
--- a/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/deployment.yaml
+++ b/samples/BikeSharingApp/BikeSharingWeb/charts/bikesharingweb/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "bikesharingweb.fullname" . }}

--- a/samples/BikeSharingApp/Bikes/charts/bikes/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Bikes/charts/bikes/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "bikes.fullname" . }}

--- a/samples/BikeSharingApp/Billing/charts/billing/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Billing/charts/billing/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "billing.fullname" . }}

--- a/samples/BikeSharingApp/Databases/charts/databases/templates/mongo.yaml
+++ b/samples/BikeSharingApp/Databases/charts/databases/templates/mongo.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hostedMongo.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "databases.fullname" . }}-mongo
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:      
+      app: {{ template "databases.fullname" . }}-mongo
   template:
     metadata:
       labels:

--- a/samples/BikeSharingApp/Databases/charts/databases/templates/sql.yaml
+++ b/samples/BikeSharingApp/Databases/charts/databases/templates/sql.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hostedSql.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "databases.fullname" . }}-sql
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "databases.fullname" . }}-sql
   template:
     metadata:
       labels:

--- a/samples/BikeSharingApp/Gateway/charts/gateway/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Gateway/charts/gateway/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "gateway.fullname" . }}

--- a/samples/BikeSharingApp/Reservation/charts/reservation/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Reservation/charts/reservation/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "reservation.fullname" . }}

--- a/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/deployment.yaml
+++ b/samples/BikeSharingApp/ReservationEngine/charts/reservationengine/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "reservationengine.fullname" . }}

--- a/samples/BikeSharingApp/Users/charts/users/templates/deployment.yaml
+++ b/samples/BikeSharingApp/Users/charts/users/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "users.fullname" . }}


### PR DESCRIPTION
…eprecated apiversions: apps/v1beta2 and extensions/v1beta1 to apps/v1 and apps/v1 respectively. Note there will be a document update needed since if there is a AKS cluster targeting version 1.16, the minimum client helm version needs to be >=2.15.1